### PR TITLE
Performance improvements when using js based map/reduce functions

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,0 @@
-include ':couchbase-lite-java-javascript', ':libraries:couchbase-lite-java-core'


### PR DESCRIPTION
Moved map/reduce functions and required js expressions to constructors so they're only executed once.